### PR TITLE
S2 addFmask_aerosolQA

### DIFF
--- a/hls_libs/common/hls_hdfeos.h
+++ b/hls_libs/common/hls_hdfeos.h
@@ -10,6 +10,7 @@
 #include "s2at30m.h"
 #include "lsat.h"
 #include "s2ang.h"
+#include "l8ang.h"
 
 /* Purely for the sake of HDFEOS; HLS processing does not rely on this. 
  * This information is copied from an opened HLS file.
@@ -70,23 +71,28 @@ bool AppendMeta(char *cbuf, int *ic, char *s);
 bool PutAttrDouble(int32 sds_id, Myhdf_attr_t *attr, double *val);
 bool PutAttrString(int32 sds_id, Myhdf_attr_t *attr, char *string);
 
-//int PutSDSDimInfo(int32 sds_id, char *dimname, int irank);
+int PutSpaceDefHDF(char *hdfname, char *struct_metadata, sds_info_t sds[], int nsds);
 
 /* S10 */
 int set_S10_sds_info(sds_info_t *s2_sds, int nsds, s2r_t *s2r);
-int S10_PutSpaceDefHDF(s2r_t *tile, sds_info_t sds[], int nsds);
+int S10_PutSpaceDefHDF(char *hdfname, sds_info_t sds[], int nsds);
 
 /* S30 */
 int set_S30_sds_info(sds_info_t *s2_sds, int nsds, s2at30m_t *s2r);
-int S30_PutSpaceDefHDF(s2at30m_t *tile, sds_info_t sds[], int nsds);
+int S30_PutSpaceDefHDF(char *hdfname, sds_info_t sds[], int nsds);
 
 /* L30 */
 int set_L30_sds_info(sds_info_t *all_sds,  int nsds,  lsat_t *lsat);
-int L30_PutSpaceDefHDF(lsat_t *tile, sds_info_t sds[], int nsds);
+int L30_PutSpaceDefHDF(char *hdfname, sds_info_t sds[], int nsds);
 
 /* solar-view angle. Works for both Sentinel and Landsat because they have the
  * same SDS names */
 int set_S2ang_sds_info(sds_info_t *all_sds,  int nsds,  s2ang_t *s2ang);
-int S2ang_PutSpaceDefHDF(s2ang_t *tile, sds_info_t sds[], int nsds);
+int set_L8ang_sds_info(sds_info_t *all_sds,  int nsds,  l8ang_t *l8ang);
+int angle_PutSpaceDefHDF(char *hdfname, sds_info_t sds[], int nsds);
+
+/* AOD, for both Landsat and Sentinel-2.  And will reuse angle_PutSpaceDefHDF() */
+// Apr 15, 2021: Abandon. Now we have the 2 bits of aerosol level.
+// int set_aod_sds_info(sds_info_t *all_sds,  int nsds, aod_t *aod);
 
 #endif

--- a/hls_libs/common/l8ang.h
+++ b/hls_libs/common/l8ang.h
@@ -1,0 +1,70 @@
+#ifndef L8ANG_H
+#define L8ANG_H
+
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "mfhdf.h"
+#include "hls_commondef.h"
+#include "hdfutility.h"
+#include "util.h"
+#include "fillval.h"
+#include "lsat.h"    /* only for constant L8NRB */
+
+#ifndef L1TSCENEID
+#define L1TSCENEID "L1T_SceneID"
+#endif
+
+#define SZ "solar_zenith"
+#define SA "solar_azimuth"
+#define VZ "view_zenith"	/* VZ and VA are part of the SDS name for a band. */
+#define VA "view_azimuth"
+
+/* SDS name for the tiled angle */ 
+static char *L8_SZ = "solar_zenith";
+static char *L8_SA = "solar_azimuth";
+static char *L8_VZ = "view_zenith";
+static char *L8_VA = "view_azimuth";
+
+typedef struct {
+	char fname[NAMELEN];
+	intn access_mode;
+	double ulx;
+	double uly;	
+	char zonehem[20]; 	/* UTM zone number and hemisphere spec */
+	int nrow;
+	int ncol;
+	char l1tsceneid[200];	/* The L1T scene ID for an S2 tile */
+
+	int32 sd_id;
+	int32 sds_id_sz;
+	int32 sds_id_sa;
+	int32 sds_id_vz;
+	int32 sds_id_va; 
+
+	/* Oct 23, 2020: Change data type from int16 to uint16 to be consistent with S2 angles.
+	 * Change the USGS int16 data to uint16 during reading. */
+	uint16 *sz;
+	uint16 *sa;
+	uint16 *vz;	
+	uint16 *va;
+
+	char tile_has_data; /* A scene and a tile may overlap so little that there is no data at all */  
+} l8ang_t;
+
+int read_l8ang_inpathrow(l8ang_t  *l8ang, char *fname);
+
+/* Open tile-based L8 angle for READ, CREATE, or WRITE. */
+int open_l8ang(l8ang_t  *l8ang, intn access_mode); 
+
+/* Add sceneID as an HDF attribute. A sceneID is added to the angle output HDF when it is
+ * first created.  And a second scene can fall on the scame S2 tile (adjacent row in the same orbit), 
+ * and this function adds the sceneID of the second scene.
+ * lsat.h has a similar function.
+ */
+int l8ang_add_l1tsceneid(l8ang_t *l8ang, char *l1tsceneid);
+
+/* close */
+int close_l8ang(l8ang_t  *l8ang);
+
+#endif

--- a/hls_libs/consolidate/consolidate.c
+++ b/hls_libs/consolidate/consolidate.c
@@ -18,6 +18,8 @@
  *   apparently selects better pixels, but there is no guarantee that terrible 
  *   atmospheric correction won't result in higher NDVI. (Finished on Jul 26, 2019)
  *
+ * Apr 1, 2020: Note that the mean sun/view angles are from twin A only; later in 
+ *   derive_s2nbar these angles will be recomputed and so set properly. 
  ********************************************************************************/
 
 #include "s2r.h"
@@ -134,7 +136,7 @@ int main(int argc, char * argv[])
 	/* Make it hdfeos */
  	sds_info_t all_sds[S2NBAND+2];
 	set_S10_sds_info(all_sds, S2NBAND+2, &s2rO);
-	ret = S10_PutSpaceDefHDF(&s2rO, all_sds, S2NBAND+2);
+	ret = S10_PutSpaceDefHDF(s2rO.fname, all_sds, S2NBAND+2);
 	if (ret != 0) {
 		Error("Error in HLS_PutSpaceDefHDF");
 		exit(1);

--- a/hls_libs/consolidate_s2ang/consolidate_s2ang.c
+++ b/hls_libs/consolidate_s2ang/consolidate_s2ang.c
@@ -87,7 +87,8 @@ int main(int argc, char *argv[])
 	/* Make it HDF-EOS */
 	sds_info_t all_sds[NANG];
         set_S2ang_sds_info(all_sds, NANG, &s2angC);
-        ret = S2ang_PutSpaceDefHDF(&s2angC, all_sds, NANG);
+        // ret = S2ang_PutSpaceDefHDF(&s2angC, all_sds, NANG);
+        ret = angle_PutSpaceDefHDF(s2angC.fname, all_sds, NANG);
         if (ret != 0) {
                 Error("Error in HLS_PutSpaceDefHDF");
                 exit(1);

--- a/hls_libs/derive_s2ang/derive_s2ang.c
+++ b/hls_libs/derive_s2ang/derive_s2ang.c
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
              	s2ang.uly -= 1e7;		// To GCTP (and HDF-EOS?) convention.
 	sds_info_t all_sds[NANG];
         set_S2ang_sds_info(all_sds, NANG, &s2ang);
-        ret = S2ang_PutSpaceDefHDF(&s2ang, all_sds, NANG);
+        ret = angle_PutSpaceDefHDF(s2ang.fname, all_sds, NANG);
         if (ret != 0) {
                 Error("Error in HLS_PutSpaceDefHDF");
                 exit(1);


### PR DESCRIPTION
1. Now the addFmaskSDS incorporates the USGS aerosolQA into the internal Fmask by inserting the aeroQA filename after the Fmask ENVI binary file:
      ./addFmaskSDs      LaSRC_hdf \
                                       fmask \
                                       aeroQA \
                                       safexml \
                                       granulexml  \
                                       LaSRC_version \
                                       S10_hdf
A USGS aerosol QA filename is like this: S2B_MSI_L1C_T52SDG_20200402_20200402_sr_aerosol.img

2. The hls_hdfeos.[hc] files are updated to reduce the repetition in the code. This shouldn't cause a problem, but consolidate.c and L8like.c need be recompiled. 