### PR TITLE
angle code for before and after PB4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base-3.1.0
+FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base-3.2.0
 ENV PREFIX=/usr/local \
     SRC_DIR=/usr/local/src \
     GCTPLIB=/usr/local/lib \
@@ -121,7 +121,7 @@ RUN pip3 install wheel
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-browse_imagery@v1.5
 RUN pip3 install libxml2-python3
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-hdf_to_cog@v1.4
-RUN pip3 install git+https://github.com/NASA-IMPACT/hls-utilities@v1.5
+RUN pip3 install git+https://github.com/NASA-IMPACT/hls-utilities@v1.8
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-cmr_stac@v1.4
 
 COPY ./scripts/* ${PREFIX}/bin/

--- a/hls_libs/common/s2detfoo.h
+++ b/hls_libs/common/s2detfoo.h
@@ -36,7 +36,19 @@ typedef struct {
 /* open s2 detfoo for read or create */
 int open_s2detfoo(s2detfoo_t *s2detfoo, intn access_mode);
 
-/* Return 100 if the detfoo vector is not found in gml.  May 1, 2017. */
+/********************************************************************************
+ * Generate the B06 detector footprint image by rasterizing the footprint vector 
+ * polygon (before PB4.0).
+ *
+ * If there is detector footprint overlap (much earlier than PB 4.0),  write at the 
+ * relevant pixels the number id_left * NDETECTOR + id_right 
+ * (id_left and id_right are the detector id on the left and right respectively.)
+ * Later on, another function will evenly split the overlap between two detectors.
+ *
+ * Return 100 if the detfoo vector is not found.  May 1, 2017.
+ *
+ * Use B06 for all other bands. Sep 7, 2020.
+ */
 int rasterize_s2detfoo(s2detfoo_t *s2detfoo, char *fname_b01_gml);
 
 /* Equally split the overlap area for each row of image.

--- a/scripts/sentinel_granule.sh
+++ b/scripts/sentinel_granule.sh
@@ -44,10 +44,20 @@ if [ "$solar_zenith_valid" == "invalid" ]; then
   exit 3
 fi
 
-# Locate DETFOO gml for Band 01.  derive_s2ang will then infer names for other bands
-detfoo_gml=$(find "${safegranuledir}/QI_DATA" -maxdepth 1 -type f -name "*DETFOO*_B01*.gml")
+# Locate detector footprint for B06
+echo "Locating detector footprint for B06"
+detfoo06_extension=$(get_detector_footprint_extension "$safedirectory")
+if [ "$detfoo06_extension" = jp2 ]; then
+  detfoo06=$(get_detector_footprint "$safedirectory")
+  detfoo06_bin="${granuledir}/detfoo06.bin"
+  gdal_translate -of ENVI "$detfoo06" "$detfoo06_bin"
+  detfoo06="$detfoo06_bin"
+else
+  detfoo06=$(get_detector_footprint "$safedirectory")
+fi
+
 echo "Running derive_s2ang"
-derive_s2ang "$xml" "$detfoo_gml" "$detfoo" "$angleoutput"
+derive_s2ang "$xml" "$detfoo06" "$detfoo" "$angleoutput"
 
 # The detfoo output is an unneccesary legacy output
 rm "$detfoo"


### PR DESCRIPTION
The angle code that works for both the before and after Processing Baseline 4.0.
To use the code,  the caller script should:
-- First look for the  B06 detector footprint gml  file  *DETFOO*_B06.gml in the /QI_DATA/ directory
-- If the gml does not exist, then look for the footprint JP2 file *DETFOO*_B06.jp2 in the same directory.
    If JP2 exist, convert it to  an ENVI plain binary, with file extension .bin
-- Finally,  call derive_s2ang by passing the B06 gml or plain binary as the 2nd  parameter file to derive_s2ang. No change for other parameter files.

Note: earlier version of derive_s2ang used the B01.gml to derive the gml filenames and create angles for all bands.  Now only B06 is used, which is representative all bands. 

Example bash script:
	# The detector footprint is either from
	#   the B06 footprint gml (before PB 4.0), or
	#   the B06 footprint JP2 image ( PB 4.0 and later).
	b06detfoo_gml=$(ls $grandirDS/GRANULE/*${tileid}*/QI_DATA/*DETFOO*_B06.gml 2>/dev/null) 
	if [ $? -eq 0 ]
	then
		b06detfoo=$b06detfoo_gml
	else
		b06detfoo_jp2=$(ls $grandirDS/GRANULE/*${tileid}*/QI_DATA/*DETFOO*_B06.jp2 2>/dev/null) 
		if [ $? -ne 0 ]
		then
			echo  "Neither detfoo gml nor jp2 exists" >&2
			exit 1
		fi

		base=$(basename $b06detfoo_jp2 .jp2)
		gdal_translate -of ENVI $b06detfoo_jp2 $PWD/$base.bin
		b06detfoo=$PWD/$base.bin
	fi
	
	# Do it.
	$CODE_BASE_DIR/S2/angle/derive_s2ang/derive_s2ang $xml $b06detfoo $detfoo $angle