### PR TITLE
feat: apply ESA pixel level quality mask for lost or degraded packets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,7 @@ RUN pip3 install wheel
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-browse_imagery@v1.7
 RUN pip3 install libxml2-python3
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-hdf_to_cog@v2.1
-RUN pip3 install git+https://github.com/NASA-IMPACT/hls-utilities@v1.9
+RUN pip3 install git+https://github.com/NASA-IMPACT/hls-utilities@v1.10
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-cmr_stac@v1.7
 
 COPY ./scripts/* ${PREFIX}/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base:38
+FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base:v3.5.2
 ENV PREFIX=/usr/local \
     SRC_DIR=/usr/local/src \
     GCTPLIB=/usr/local/lib \

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,7 @@ RUN pip3 install wheel
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-browse_imagery@v1.7
 RUN pip3 install libxml2-python3
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-hdf_to_cog@v2.1
-RUN pip3 install git+https://github.com/NASA-IMPACT/hls-utilities@ceh/mask-all-bands
+RUN pip3 install git+https://github.com/NASA-IMPACT/hls-utilities@v1.10
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-cmr_stac@v1.7
 
 COPY ./scripts/* ${PREFIX}/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,7 @@ RUN pip3 install wheel
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-browse_imagery@v1.7
 RUN pip3 install libxml2-python3
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-hdf_to_cog@v2.1
-RUN pip3 install git+https://github.com/NASA-IMPACT/hls-utilities@v1.10
+RUN pip3 install git+https://github.com/NASA-IMPACT/hls-utilities@ceh/mask-all-bands
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-cmr_stac@v1.7
 
 COPY ./scripts/* ${PREFIX}/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base:v3.5.1
+FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base:38
 ENV PREFIX=/usr/local \
     SRC_DIR=/usr/local/src \
     GCTPLIB=/usr/local/lib \

--- a/scripts/sentinel_granule.sh
+++ b/scripts/sentinel_granule.sh
@@ -63,7 +63,7 @@ apply_s2_quality_mask "$safegranuledir"
 echo "Running derive_s2ang"
 derive_s2ang "$xml" "$detfoo06" "$detfoo" "$angleoutput"
 
-# The detfoo output is an unneccesary legacy output
+# The detfoo output is an unnecessary legacy output
 rm "$detfoo"
 
 # Check Sentinel cloud metadata.

--- a/scripts/sentinel_granule.sh
+++ b/scripts/sentinel_granule.sh
@@ -54,6 +54,11 @@ else
   detfoo06=$(get_detector_footprint "$safedirectory")
 fi
 
+# Apply ESA's pixel-level quality mask for lost or degraded packets
+# This script updates the L1C imagery in-place by setting affected pixels
+# to the L1C "nodata" value (0)
+apply_s2_quality_mask "$safegranuledir"
+
 # Run derive_s2ang
 echo "Running derive_s2ang"
 derive_s2ang "$xml" "$detfoo06" "$detfoo" "$angleoutput"

--- a/scripts/sentinel_granule.sh
+++ b/scripts/sentinel_granule.sh
@@ -87,6 +87,7 @@ if [ "$fmask_valid" == "invalid" ] && [ "$cloud_cover_valid" == "invalid" ]; the
   echo "Fmask reports no clear pixels. Exiting now"
   exit 4
 fi
+rm fmask_out.txt
 
 fmask="${safegranuledir}/FMASK_DATA/${grandir_id}_Fmask4.tif"
 
@@ -96,16 +97,15 @@ gdal_translate -of ENVI "$fmask" "$fmaskbin"
 
 cd "$granuledir"
 
-# Removes previously unzipped SAFE directory for replacement with ESPA unpacking
-# result
-rm -rf "${granule}.SAFE"
+# Re-zip the (potentially masked) SAFE directory for custom unzipping by ESPA
+# unpacking script
+masked_safezip=${safezip}.masked.zip
+zip -r $masked_safezip $safegranuledir
+# remove original SAFE zip to save disk space
+rm $safezip
 
-unpackage_s2.py -i "$safezip" -o "$granuledir"
-rm "$safezip"
-
-# Apply ESA's pixel-level quality mask for lost or degraded packets AGAIN
-# We need to do this twice because the previous step nuked the original SAFE file
-apply_s2_quality_mask "$safegranuledir"
+unpackage_s2.py -i "$masked_safezip" -o "$granuledir"
+rm $masked_safezip
 
 # Convert to espa format
 cd "$safedirectory"

--- a/scripts/sentinel_granule.sh
+++ b/scripts/sentinel_granule.sh
@@ -100,12 +100,12 @@ cd "$granuledir"
 # Re-zip the (potentially masked) SAFE directory for custom unzipping by ESPA
 # unpacking script
 masked_safezip=${safezip}.masked.zip
-zip -r $masked_safezip $safegranuledir
+zip -r "$masked_safezip" "$safegranuledir"
 # remove original SAFE zip to save disk space
-rm $safezip
+rm "$safezip"
 
 unpackage_s2.py -i "$masked_safezip" -o "$granuledir"
-rm $masked_safezip
+rm "$masked_safezip"
 
 # Convert to espa format
 cd "$safedirectory"

--- a/scripts/sentinel_granule.sh
+++ b/scripts/sentinel_granule.sh
@@ -91,9 +91,10 @@ rm fmask_out.txt
 
 fmask="${safegranuledir}/FMASK_DATA/${grandir_id}_Fmask4.tif"
 
-echo "Converting to flat binary"
+echo "Converting Fmask to flat binary at $fmaskbin"
 # Convert to flat binary
 gdal_translate -of ENVI "$fmask" "$fmaskbin"
+rm -rf "${safegranuledir}/FMASK_DATA"
 
 cd "$granuledir"
 

--- a/scripts/sentinel_granule.sh
+++ b/scripts/sentinel_granule.sh
@@ -101,7 +101,7 @@ cd "$granuledir"
 # Re-zip the (potentially masked) SAFE directory for custom unzipping by ESPA
 # unpacking script
 masked_safezip=${safezip}.masked.zip
-zip -r "${masked_safezip}" "$(basename $safedirectory)"
+zip -r "${masked_safezip}" "$(basename "$safedirectory")"
 # remove original SAFE zip to save disk space
 rm "$safezip"
 

--- a/scripts/sentinel_granule.sh
+++ b/scripts/sentinel_granule.sh
@@ -101,7 +101,7 @@ cd "$granuledir"
 # Re-zip the (potentially masked) SAFE directory for custom unzipping by ESPA
 # unpacking script
 masked_safezip=${safezip}.masked.zip
-zip -r "$masked_safezip" "$safedirectory"
+zip -r "${masked_safezip}" "$(basename $safedirectory)"
 # remove original SAFE zip to save disk space
 rm "$safezip"
 

--- a/scripts/sentinel_granule.sh
+++ b/scripts/sentinel_granule.sh
@@ -101,7 +101,7 @@ cd "$granuledir"
 # Re-zip the (potentially masked) SAFE directory for custom unzipping by ESPA
 # unpacking script
 masked_safezip=${safezip}.masked.zip
-zip -r "$masked_safezip" "$safegranuledir"
+zip -r "$masked_safezip" "$safedirectory"
 # remove original SAFE zip to save disk space
 rm "$safezip"
 

--- a/scripts/sentinel_granule.sh
+++ b/scripts/sentinel_granule.sh
@@ -103,6 +103,10 @@ rm -rf "${granule}.SAFE"
 unpackage_s2.py -i "$safezip" -o "$granuledir"
 rm "$safezip"
 
+# Apply ESA's pixel-level quality mask for lost or degraded packets AGAIN
+# We need to do this twice because the previous step nuked the original SAFE file
+apply_s2_quality_mask "$safegranuledir"
+
 # Convert to espa format
 cd "$safedirectory"
 convert_sentinel_to_espa


### PR DESCRIPTION
This PR addresses https://github.com/NASA-IMPACT/hls-sentinel/issues/155

In https://github.com/NASA-IMPACT/hls-utilities/pull/15 we added a CLI utility to apply ESA's pixel level mask to mask pixels that were affected by lost or degraded packets during transmission to ground receiving stations. This utility modifies the L1C granule imagery in place for any band affected by the issue.

The script is intended to be very lazy,
* It first checks a metadata file to identify if any bands used by HLS product are affected and exits early if no bands are affected by any potential quality issue.
* If a band is affected we first check to see if the band's mask is affected by the 2 conditions we're concerned about (lost or degraded packets). The mask image is a bitmask for 8 possible conditions, and we exit early if none of the pixels are affected by the lost or degraded packet issue.
* The script will only perform the relatively expensive process of masking and rewriting the JP2 images if these two checks do not exit early

I put this masking step ahead of running Fmask so that we can get a more accurate assessment of if there are any valid and non-(cloudy | shadowed | etc) pixels in the image.