### PR TITLE
fix: Update ACCODE metadata to v3.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV PREFIX=/usr/local \
     HDFLINK=" -lmfhdf -ldf -lm" \
     ECS_ENABLE_TASK_IAM_ROLE=true \
     PYTHONPATH="${PYTHONPATH}:${PREFIX}/lib/python3.6/site-packages" \
-    ACCODE=LaSRCL8V3.5.1 \
+    ACCODE="LaSRC v3.5.2" \
     LC_ALL=en_US.utf-8 \
     LANG=en_US.utf-8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,7 @@ RUN pip3 install --upgrade awscli
 RUN pip3 install click==7.1.2
 RUN pip3 install rio-cogeo==1.1.10 --no-binary rasterio --user
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-thumbnails@v1.3
-RUN pip3 install git+https://github.com/NASA-IMPACT/hls-metadata@v2.6
+RUN pip3 install git+https://github.com/NASA-IMPACT/hls-metadata@feat/bump-accode-v3.5.2
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-manifest@v2.1
 RUN pip3 install wheel
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-browse_imagery@v1.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,7 @@ RUN pip3 install --upgrade awscli
 RUN pip3 install click==7.1.2
 RUN pip3 install rio-cogeo==1.1.10 --no-binary rasterio --user
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-thumbnails@v1.3
-RUN pip3 install git+https://github.com/NASA-IMPACT/hls-metadata@feat/bump-accode-v3.5.2
+RUN pip3 install git+https://github.com/NASA-IMPACT/hls-metadata@v2.7
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-manifest@v2.1
 RUN pip3 install wheel
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-browse_imagery@v1.7

--- a/scripts/sentinel.sh
+++ b/scripts/sentinel.sh
@@ -15,7 +15,6 @@ bucket_role_arn="$GCC_ROLE_ARN"
 debug_bucket="$DEBUG_BUCKET"
 replace_existing="$REPLACE_EXISTING"
 gibs_bucket="$GIBS_OUTPUT_BUCKET"
-ACCODE="LaSRC v3.5.2"
 
 # Remove tmp files on exit
 # shellcheck disable=SC2064

--- a/scripts/sentinel.sh
+++ b/scripts/sentinel.sh
@@ -15,6 +15,7 @@ bucket_role_arn="$GCC_ROLE_ARN"
 debug_bucket="$DEBUG_BUCKET"
 replace_existing="$REPLACE_EXISTING"
 gibs_bucket="$GIBS_OUTPUT_BUCKET"
+ACCODE="LaSRC v3.5.2"
 
 # Remove tmp files on exit
 # shellcheck disable=SC2064

--- a/scripts/sentinel_granule.sh
+++ b/scripts/sentinel_granule.sh
@@ -134,11 +134,11 @@ convert_espa_to_hdf --xml="$hls_espa_two_xml" --hdf="$sr_hdf_two"
 
 # Combine split hdf files and resample 10M SR bands back to 20M and 60M.
 echo "Combining hdf files"
-twohdf2one "$sr_hdf_one" "$sr_hdf_two" MTD_MSIL1C.xml MTD_TL.xml LaSRC "$hls_sr_combined_hdf"
+twohdf2one "$sr_hdf_one" "$sr_hdf_two" MTD_MSIL1C.xml MTD_TL.xml "$ACCODE" "$hls_sr_combined_hdf"
 
 # Run addFmaskSDS
 echo "Adding Fmask SDS"
-addFmaskSDS "$hls_sr_combined_hdf" "$fmaskbin" "$aerosol_qa" MTD_MSIL1C.xml MTD_TL.xml LaSRC "$hls_sr_output_hdf"
+addFmaskSDS "$hls_sr_combined_hdf" "$fmaskbin" "$aerosol_qa" MTD_MSIL1C.xml MTD_TL.xml "$ACCODE" "$hls_sr_output_hdf"
 
 # Trim edge pixels for spurious SR values
 echo "Trimming output hdf file"

--- a/scripts/sentinel_granule.sh
+++ b/scripts/sentinel_granule.sh
@@ -4,6 +4,8 @@
 # Exit on any error
 set -o errexit
 
+ACCODE="LaSRC v3.5.2"
+
 # granule, granuledir, inputbucket, angleoutput, granuleoutput variable set in sentinel.sh
 safedirectory="${granuledir}/${granule}.SAFE"
 safezip="${granuledir}/${granule}.zip"


### PR DESCRIPTION
This PR creates two changes so we reflect the current version of LaSRC in our product metadata,

* Define `ACCODE=LaSRC v3.5.2` (previously just `LaSRC`) in the HDFs so this information is propagated to our output COGs
* Update `hls-metadata` to a newer version so our CMR XML file contains the updated version (from `LaSRC v3.5.1` to `LaSRC v3.5.2`)

This also resolves an inconsistency in the metadata values for `ACCODE` between our product COGs and our product metadata.