### PR TITLE
fix: Use v3.5.1.0 for fork of LaSRC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base:v3.5.2
+FROM 018923174646.dkr.ecr.us-west-2.amazonaws.com/hls-base:v3.5.1.0
 ENV PREFIX=/usr/local \
     SRC_DIR=/usr/local/src \
     GCTPLIB=/usr/local/lib \
@@ -13,7 +13,7 @@ ENV PREFIX=/usr/local \
     HDFLINK=" -lmfhdf -ldf -lm" \
     ECS_ENABLE_TASK_IAM_ROLE=true \
     PYTHONPATH="${PYTHONPATH}:${PREFIX}/lib/python3.6/site-packages" \
-    ACCODE="LaSRC v3.5.2" \
+    ACCODE="LaSRC v3.5.1.0" \
     LC_ALL=en_US.utf-8 \
     LANG=en_US.utf-8
 

--- a/scripts/sentinel_granule.sh
+++ b/scripts/sentinel_granule.sh
@@ -4,7 +4,7 @@
 # Exit on any error
 set -o errexit
 
-ACCODE="LaSRC v3.5.2"
+ACCODE="LaSRC v3.5.1.0"
 
 # granule, granuledir, inputbucket, angleoutput, granuleoutput variable set in sentinel.sh
 safedirectory="${granuledir}/${granule}.SAFE"


### PR DESCRIPTION
We're going to append a "maintainer version" to the version we've forked LaSRC from instead of incrementing the patch version to reduce potential confusion. This PR changes the upstream tag to `v3.5.1.0`