### PR TITLE
fix: bump hls-utilities for bugfix in Sentinel QAQC masking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ RUN pip3 install wheel
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-browse_imagery@v1.7
 RUN pip3 install libxml2-python3
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-hdf_to_cog@v2.1
-RUN pip3 install git+https://github.com/NASA-IMPACT/hls-utilities@v1.10
+RUN pip3 install git+https://github.com/NASA-IMPACT/hls-utilities@v1.11
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-cmr_stac@v1.7
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-vi@v1.17
 


### PR DESCRIPTION
This PR updates the `hls-utilities` package for a bugfix with the Sentinel-2 "lost/degraded packets" masking, see https://github.com/NASA-IMPACT/hls-utilities/pull/17

Before,
![HLS S30 T13RDM 2025137T173921 v2 0](https://github.com/user-attachments/assets/e515c204-5ff6-4cb1-b619-eb047fad54bf)

After,
![HLS S30 T13RDM 2025137T173921 v2 0](https://github.com/user-attachments/assets/2b3a594c-ece2-4dcc-a717-84ff382730f2)
