### PR TITLE
fix: bump hls-utilities to mask all S2 bands for lost/dropped packets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,7 @@ RUN pip3 install git+https://github.com/NASA-IMPACT/hls-metadata@v2.7
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-manifest@v2.1
 RUN pip3 install wheel
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-browse_imagery@v1.7
-RUN pip3 install libxml2-python3
+RUN pip3 install git+https://github.com/flyingcircusio/libxml2-python3
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-hdf_to_cog@v2.1
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-utilities@fix/mask-all-bands
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-cmr_stac@v1.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,7 @@ RUN pip3 install git+https://github.com/NASA-IMPACT/hls-metadata@v2.7
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-manifest@v2.1
 RUN pip3 install wheel
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-browse_imagery@v1.7
-RUN pip3 install git+https://github.com/flyingcircusio/libxml2-python3
+RUN pip3 install git+https://github.com/NASA-IMPACT/libxml2-python3
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-hdf_to_cog@v2.1
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-utilities@v1.11.1
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-cmr_stac@v1.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ RUN pip3 install wheel
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-browse_imagery@v1.7
 RUN pip3 install git+https://github.com/flyingcircusio/libxml2-python3
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-hdf_to_cog@v2.1
-RUN pip3 install git+https://github.com/NASA-IMPACT/hls-utilities@fix/mask-all-bands
+RUN pip3 install git+https://github.com/NASA-IMPACT/hls-utilities@v1.11.1
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-cmr_stac@v1.7
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-vi@v1.17
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ RUN pip3 install wheel
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-browse_imagery@v1.7
 RUN pip3 install libxml2-python3
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-hdf_to_cog@v2.1
-RUN pip3 install git+https://github.com/NASA-IMPACT/hls-utilities@v1.11
+RUN pip3 install git+https://github.com/NASA-IMPACT/hls-utilities@fix/mask-all-bands
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-cmr_stac@v1.7
 RUN pip3 install git+https://github.com/NASA-IMPACT/hls-vi@v1.17
 


### PR DESCRIPTION
This PR bumps the `hls-utilities` library to include the fix from this PR,
https://github.com/NASA-IMPACT/hls-utilities/pull/18

Along the way I had to find a new source for `libxml2-python3` since it appears to have been pulled from PyPI 😭 